### PR TITLE
Desabilitando modo restrito

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
+    "strict": false, //desabilitando modo restrito
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,


### PR DESCRIPTION
Desabilitando modo restrito para evitar erros de compilação por causa desse modo.
Modo restrito gera muita incompatibilidades com código criado por ele fazer muitas restrições a criação de objetos.