### PR TITLE
add exports no modulo do jogo

### DIFF
--- a/src/app/jogo-da-velha/jogo-da-velha.module.ts
+++ b/src/app/jogo-da-velha/jogo-da-velha.module.ts
@@ -10,6 +10,10 @@ import { JogoDaVelhaComponent } from './jogo-da-velha.component';
   ],
   imports: [
     CommonModule
+  ],
+  //Add exports para que o modulo da aplicação consiga vizualizar a tag html
+  exports: [
+    JogoDaVelhaComponent
   ]
 })
 export class JogoDaVelhaModule { }


### PR DESCRIPTION
add Export no modulo: jogo-da-velha.module.ts
- É preciso colocar esse export para que o módulo da aplicação vizualize a tag html.
- O nome da tag localizado em jogo-da-velha.component.ts dentro do selector, com nome: 'app-jogo-da-velha'