### PR TITLE
Logica de simular jogada da cpu

### DIFF
--- a/src/app/jogo-da-velha/shared/jogo-da-velha.service.ts
+++ b/src/app/jogo-da-velha/shared/jogo-da-velha.service.ts
@@ -171,4 +171,60 @@ export class JogoDaVelhaService {
 
       return fim;
   }
+  /**
+   * Lógica para simular jogada do computador em modo aleatório.
+   *
+   * @return void
+   */
+  cpuJogar(): void {
+    //verifica jogada de vitória
+    let jogada: number[] = this.obterJogada(this.O);
+
+    if (jogada.length <= 0) {
+      //tenta jogar para evitar derrota
+      jogada = this. obterJogada(this.X);
+    }
+
+    if (jogada.length <= 0) {
+      //joga aleatório
+      let jogadas: any = [];
+      for (let i=0; i<this.TAM_TAB; i++) {
+        for (let j=0; j<this.TAM_TAB; j++) {
+          if (this.tabuleiro[i][j] === this.VAZIO) {
+            jogadas.push([i, j]);
+          }
+        }
+      }
+      let k = Math.floor((Math.random() * (jogadas.length - 1)));
+      jogada = [jogadas[k][0], jogadas[k][1]];
+    }
+
+    this.tabuleiro[jogada[0]][jogada[1]] = this._jogador;
+    this.numMovimentos++;
+    this.vitoria = this.fimJogo(jogada[0], jogada[1],
+      this.tabuleiro, this._jogador)
+    this._jogador = (this._jogador === this.X) ? this.O : this.X;
+  }
+   /**
+   * Obtém uma jogada válida para vitória de um jogador.
+   *
+   * @param number jogador
+   * @return nomber[]
+   */
+  obterJogada(jogador: number): number[] {
+    let tab = this.tabuleiro;
+    for (let lin = 0; lin < this.TAM_TAB; lin++) {
+      for(let col = 0; col < this.TAM_TAB; col++) {
+        if (tab[lin][col] !== this.VAZIO) {
+          continue;
+        }
+        tab[lin][col] = jogador;
+        if (this.fimJogo(lin, col, tab, jogador)) {
+          return [lin, col];
+        }
+        tab[lin][col] = this.VAZIO;
+      }
+    }
+    return [];
+  }
 }


### PR DESCRIPTION
Add Logica de simular jogada da cpu. Metodos criado:
- escopo cpuJogar
- verificação da jogada de vitória.
- jogada para evitar derrota.
- jogo aleatório.
